### PR TITLE
:snake_case_symbol keys

### DIFF
--- a/lib/faraday_middleware/parse_oj.rb
+++ b/lib/faraday_middleware/parse_oj.rb
@@ -3,12 +3,19 @@ require 'faraday_middleware/response_middleware'
 module FaradayMiddleware
   class ParseOj < ResponseMiddleware
     dependency 'oj'
-    
+
     define_parser do |body|
-      Oj.load(body, mode: :compat) unless body.strip.empty?
+      data = Oj.load(body, mode: :compat) unless body.strip.empty?
+      if data.respond_to?('deep_transform_keys!')
+        data.deep_transform_keys! { |key| key.underscore.to_sym }
+      else
+        data = {'root'=> data} # Wrap data to ensure deep_transform_keys works
+        data.deep_transform_keys! { |key| key.underscore.to_sym }
+        data = data[:root] # Back to original structure
+      end
     end
-    
-    VERSION = '0.3.0'
+
+    VERSION = '0.3.0.1'
   end
 end
 

--- a/lib/faraday_middleware/parse_oj.rb
+++ b/lib/faraday_middleware/parse_oj.rb
@@ -3,6 +3,21 @@ require 'faraday_middleware/response_middleware'
 module FaradayMiddleware
   class ParseOj < ResponseMiddleware
     dependency 'oj'
+    
+    define_parser do |body|
+      Oj.load(body, mode: :compat) unless body.strip.empty?
+    end
+    
+    VERSION = '0.3.0'
+  end
+end
+
+Faraday::Response.register_middleware oj: FaradayMiddleware::ParseOj
+
+# Ruby-like syntax with hash[:snake_cased] symbol keys
+module FaradayMiddleware
+  class ParseOjToSymbols < ResponseMiddleware
+    dependency 'oj'
 
     define_parser do |body|
       data = Oj.load(body, mode: :compat) unless body.strip.empty?
@@ -15,8 +30,8 @@ module FaradayMiddleware
       end
     end
 
-    VERSION = '0.3.0.1'
+    VERSION = '0.3.0'
   end
 end
 
-Faraday::Response.register_middleware oj: FaradayMiddleware::ParseOj
+Faraday::Response.register_middleware oj_to_symbols: FaradayMiddleware::ParseOjToSymbols

--- a/lib/faraday_middleware/parse_oj.rb
+++ b/lib/faraday_middleware/parse_oj.rb
@@ -24,8 +24,8 @@ module FaradayMiddleware
       if data.respond_to?('deep_transform_keys!')
         data.deep_transform_keys! { |key| key.underscore.to_sym }
       else
-        data = {'root'=> data} # Wrap data to ensure deep_transform_keys works
-        data.deep_transform_keys! { |key| key.underscore.to_sym }
+        data = {root: data} # Wrap data to ensure deep_transform_keys works
+        data.deep_transform_keys! { |key| key.to_s.underscore.to_sym } # Base key may not have been a string
         data = data[:root] # Back to original structure
       end
     end

--- a/spec/parse_oj_spec.rb
+++ b/spec/parse_oj_spec.rb
@@ -20,3 +20,24 @@ describe FaradayMiddleware::ParseOj do
     expect(@connection.get('/url').body).to eq(@parsed_body)
   end
 end
+
+describe FaradayMiddleware::ParseOjToSymbols do
+  before(:each) do
+    @body = '{"keyA": 1, "keyB": 2}'
+    @parsed_body = {key_a: 1, key_b:2}
+    
+    @connection = Faraday.new do |builder|
+      builder.response :oj_to_symbols
+      builder.adapter :test do |stub|
+        stub.get('/url') do
+          [200, {}, @body]
+        end
+      end
+    end
+  end
+  
+  it "parses the response body with Oj.load" do
+    expect(Oj).to receive(:load).with(@body, mode: :compat).and_return(@parsed_body)
+    expect(@connection.get('/url').body).to eq(@parsed_body)
+  end
+end


### PR DESCRIPTION
Ruby-like structure for JSON data. Hash keys are snake_cased and symbols.

Note that the local tests were much more extensive than those in this project but decided to match the simplicity of this spec.
