### PR TITLE
relax gemspec to support oj 3.0

### DIFF
--- a/faraday_middleware-parse_oj.gemspec
+++ b/faraday_middleware-parse_oj.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'faraday',            '~> 0.9'
   gem.add_runtime_dependency 'faraday_middleware', '>= 0.9.1', '< 1.0'
-  gem.add_runtime_dependency 'oj',                 '~> 2.0'
+  gem.add_runtime_dependency 'oj',                 '>= 2.0', '< 4.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
OJ 3.0 was recently released, https://github.com/ohler55/oj/blob/master/CHANGELOG.md#300---2017-04-24. "Major changes focussed on json gem and Rails compatibility."